### PR TITLE
escape tagText for regex

### DIFF
--- a/lib/double-tag.coffee
+++ b/lib/double-tag.coffee
@@ -79,7 +79,7 @@ class DoubleTag
     row = @frontOfStartTag.row
     rowLength = @editor.buffer.lineLengthForRow(row)
 
-    backRegex = /[>\s]/
+    backRegex = /[^\w-]/
     endOfLine = new Point(row, rowLength)
     scanRange = new Range(@frontOfStartTag, endOfLine)
     backOfStartTag = null
@@ -103,7 +103,8 @@ class DoubleTag
     true
 
   findEndTag: ->
-    tagRegex = new RegExp("<\\/?#{@tagText}[>\\s]", 'gi')
+    regexSafeTagText = @tagText.replace(/[-[\]{}()*+!<=:?.\/\\^$|#\s,]/g, '\\$&')
+    tagRegex = new RegExp("<\\/?#{regexSafeTagText}[>\\s]", 'gi')
     endTagRange = null
     nestedTagCount = 0
     scanRange = new Range(@backOfStartTag, @editor.buffer.getEndPosition())

--- a/spec/double-tag-spec.coffee
+++ b/spec/double-tag-spec.coffee
@@ -242,3 +242,14 @@ describe "DoubleTag", ->
           editor.backspace()
 
           expect(editor.getText()).toBe '<fo\n  class="bar">foobar</fo>'
+
+    describe "with parenthesis after tag", ->
+      beforeEach ->
+        editor.setText('<foo( class="bar">foobar</foo>')
+
+      describe "when letter is removed", ->
+        it "removes letter from end tag", ->
+          editor.setCursorBufferPosition([0, 4])
+          editor.backspace()
+
+          expect(editor.getText()).toBe '<fo( class="bar">foobar</fo>'


### PR DESCRIPTION
`tagText` could include regex special characters such as `(` and `)` so it would fail when creating the regex in `findEndTag`.

Alternatively we could change the regex in `setBackOfStartTag` to something more restrictive to filter out any non-valid tag character but I wasn't sure if there was a reason it was not already restrictive. Also it would still be a good idea to escape the `tagText` before creating the regex in `findEndTag`.