### PR TITLE
Remove undo option from setTextInBufferRange

### DIFF
--- a/lib/double-tag.coffee
+++ b/lib/double-tag.coffee
@@ -66,11 +66,8 @@ class DoubleTag
       return @reset() unless matches
       newTag = matches[0]
     newTagLength = newTag.length
-    @editor.setTextInBufferRange(
-      @endMarker.getBufferRange(),
-      newTag,
-      undo: 'skip'
-    )
+    @editor.setTextInBufferRange(@endMarker.getBufferRange(), newTag)
+    @editor.buffer.groupLastChanges()
     # reset if a space was added
     @reset() unless origTagLength != null and newTagLength != null and
                     origTagLength == newTagLength
@@ -85,11 +82,8 @@ class DoubleTag
       return @reset() unless matches
       newTag = matches[0]
     newTagLength = newTag.length
-    @editor.setTextInBufferRange(
-      @startMarker.getBufferRange(),
-      newTag,
-      undo: 'skip'
-    )
+    @editor.setTextInBufferRange(@startMarker.getBufferRange(), newTag)
+    @editor.buffer.groupLastChanges()
     # reset if a space was added
     @reset() unless origTagLength != null and newTagLength != null and
                     origTagLength == newTagLength


### PR DESCRIPTION
The option is deprecated
https://github.com/atom/text-buffer/pull/282

They changed the behaviour of the undo option and it no longer works.
This also broke core:redo with this package.  I wasn't able to fix redo,
so this commit is only a partial fix.

Fixes #36